### PR TITLE
Update to Python 3.7

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: "python:3.6"
+type: "python:3.7"
 
 # The build-time dependencies of the app.
 dependencies:

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,6 @@ flask = "*"
 gevent = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9245b46e39b50b9fc2a04e735806494f539ce3f0d45185781c3e24f9512079f2"
+            "sha256": "5eca26c114de5dde98d935448b2914516d25c2ac98cf7a1d5afd453441542475"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Platform.sh Python 3.6 minimal example
+# Platform.sh Python 3 minimal example
 
-This project provides a starter kit for minimal Python 3.6 projects hosted on Platform.sh. It is primarily an example, although could be used as the starting point for a real project.
+This project provides a starter kit for minimal Python 3 projects hosted on Platform.sh. Multiple Python 3 [versions](https://docs.platform.sh/languages/python.html#supported-versions) are supported. It is primarily an example, although could be used as the starting point for a real project.
 
 Notice specifically the `server.py` where we read some of the environment variables and configure the App
 to connect to the correct database and to a redis instance.


### PR DESCRIPTION
Python 3.7 container is now available, let's use it in the examples. This repository should be renamed to platformsh-example-python-3.X or something similar.
